### PR TITLE
Add additional parameter for text color

### DIFF
--- a/lib/fastlane/plugin/icon_versioning/actions/version_icon_action.rb
+++ b/lib/fastlane/plugin/icon_versioning/actions/version_icon_action.rb
@@ -93,6 +93,14 @@ module Fastlane
             description: 'An optional regex that causes the icons that match agains it not to be versioned',
             optional: true,
             type: Regexp
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :text_color,
+            env_name: 'VERSION_ICON_TEXT_COLOR',
+            default_value: 'white',
+            description: 'A color of the text overlaying the icon images. A HEX value or a color name will work here',
+            optional: true,
+            type: String
           )
         ]
       end

--- a/lib/fastlane/plugin/icon_versioning/helper/version_icon_helper.rb
+++ b/lib/fastlane/plugin/icon_versioning/helper/version_icon_helper.rb
@@ -135,7 +135,7 @@ module Fastlane
         MiniMagick::Tool::Convert.new do |convert|
           convert << '-background' << 'none'
           convert << '-size' << "#{image_width - (text_left_margin + text_right_margin)}x#{band_height - (text_top_margin + text_bottom_margin)}"
-          convert << '-fill' << "#{@color}"
+          convert << '-fill' << @color
           convert << '-gravity' << 'center'
           # using label instead of caption prevents wrapping long lines
           convert << "label:#{@text}"

--- a/lib/fastlane/plugin/icon_versioning/helper/version_icon_helper.rb
+++ b/lib/fastlane/plugin/icon_versioning/helper/version_icon_helper.rb
@@ -16,6 +16,7 @@ module Fastlane
       def initialize(params)
         @appiconset_path = File.expand_path(params[:appiconset_path])
         @text = params[:text]
+        @color = params[:text_color]
 
         text_margins_percentages = params[:text_margins_percentages]
 
@@ -134,7 +135,7 @@ module Fastlane
         MiniMagick::Tool::Convert.new do |convert|
           convert << '-background' << 'none'
           convert << '-size' << "#{image_width - (text_left_margin + text_right_margin)}x#{band_height - (text_top_margin + text_bottom_margin)}"
-          convert << '-fill' << 'white'
+          convert << '-fill' << "#{@color}"
           convert << '-gravity' << 'center'
           # using label instead of caption prevents wrapping long lines
           convert << "label:#{@text}"


### PR DESCRIPTION
Turned out the default white text doesn't work well with icons with white as a dominant color